### PR TITLE
Added support for mutable torrents

### DIFF
--- a/app/protocols/bt-protocol.js
+++ b/app/protocols/bt-protocol.js
@@ -1,8 +1,9 @@
-const makeFetch = require('bt-fetch')
 const fetchToHandler = require('./fetch-to-handler')
 
 module.exports = async function createHandler (options, session) {
   return fetchToHandler(async () => {
+    const makeFetch = require('bt-fetch')
+
     const fetch = makeFetch(options)
 
     return fetch

--- a/app/protocols/magnet-protocol.js
+++ b/app/protocols/magnet-protocol.js
@@ -1,6 +1,7 @@
 const { Readable } = require('stream')
 
 const INFO_HASH_MATCH = /^urn:btih:([a-f0-9]{40})$/ig
+const PUBLIC_KEY_MATCH = /^urn:btpk:([a-f0-9]{64})$/ig
 
 module.exports = async function createHandler () {
   return function magnetHandler (req, sendResponse) {
@@ -8,26 +9,39 @@ module.exports = async function createHandler () {
       const parsed = new URL(req.url)
 
       const xt = parsed.searchParams.get('xt')
-      if (!xt) {
-        sendError('Magnet link has no `xt` parameter')
-      } else {
+      const xs = parsed.searchParams.get('xs')
+
+      if (xs) {
+        const match = PUBLIC_KEY_MATCH.exec(xs)
+        if (!match) {
+          return sendError('Magnet has no bittorrent infohash')
+        }
+        const publicKey = match[1]
+        const final = `bittorrent://${publicKey}`
+        sendFinal(final)
+      } else if (xt) {
         const match = INFO_HASH_MATCH.exec(xt)
         if (!match) {
-          sendError('Magnet has no bittorrent infohash')
-        } else {
-          const infohash = match[1]
-          const final = `bittorrent://${infohash}/`
-          sendResponse({
-            statusCode: 308,
-            headers: {
-              Location: final
-            },
-            data: intoStream('')
-          })
+          return sendError('Magnet has no bittorrent infohash')
         }
+        const infohash = match[1]
+        const final = `bittorrent://${infohash}/`
+        sendFinal(final)
+      } else {
+        return sendError('Magnet link has no `xt` or `xs` parameter')
       }
     } catch (e) {
       sendError(e.stack)
+    }
+
+    function sendFinal (Location) {
+      sendResponse({
+        statusCode: 308,
+        headers: {
+          Location
+        },
+        data: intoStream('')
+      })
     }
 
     function sendError (message) {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "bt-fetch": "^1.2.0",
+    "bt-fetch": "^2.0.0",
     "create-desktop-shortcuts": "^1.4.0",
     "data-uri-to-buffer": "^3.0.1",
     "electron-extensions": "^6.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,15 +1514,16 @@ browserify-package-json@^1.0.0:
   resolved "https://registry.yarnpkg.com/browserify-package-json/-/browserify-package-json-1.0.1.tgz#98dde8aa5c561fd6d3fe49bbaa102b74b396fdea"
   integrity sha1-mN3oqlxWH9bT/km7qhArdLOW/eo=
 
-bt-fetch@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/bt-fetch/-/bt-fetch-1.2.0.tgz#76c383e100d6c674c93aa3c512b3c1f40a02d2cd"
-  integrity sha512-dM4fL6DSPfCtpEs/X42/F4jYozcGH8MrDL6TPTK/X5zF9zBa6RISEPNaSVPmx4ma0NxeB0vIN62AF9y0IcBA0w==
+bt-fetch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bt-fetch/-/bt-fetch-2.0.0.tgz#aeb63b1c3eb2348d2d01a3053ffa0c8dd82cf8c2"
+  integrity sha512-Ia/rVxR7LAbr7jBITBU56ffrkCaMBP6fJks53mpBV7JuLE85w4ok/9mN/9/lrBb/5xqLiFlCYr1U3IrpazBNxg==
   dependencies:
     make-fetch "^2.3.1"
     mime "^2.5.2"
     range-parser "^1.2.1"
     stream-async-iterator "^2.0.0"
+    webproperty "^1.6.3"
     webtorrent "^0.116.0"
 
 buffer-alloc-unsafe@^1.1.0:
@@ -2541,6 +2542,14 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ed25519-supercop@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ed25519-supercop/-/ed25519-supercop-2.0.1.tgz#5b317dec9b17a0ff2c303d2a5b600983f9df1806"
+  integrity sha512-5K75apA428ygTu/uvWwfOPPqdw65v7lFDLX6CSsV/ByhhVR5xED93KXeKDEMZ7G2Ttd3RyQoL8pFGSoMEWBXHA==
+  dependencies:
+    napi-macros "^2.0.0"
+    node-gyp-build "^4.2.3"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -5311,7 +5320,7 @@ level-supports@^2.0.1:
   resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-2.1.0.tgz#9af908d853597ecd592293b2fad124375be79c5f"
   integrity sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==
 
-level@^7.0.0:
+level@^7.0.0, level@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/level/-/level-7.0.1.tgz#05121748d95a4ff7355860d56eb5d0aa36faef2a"
   integrity sha512-w3E64+ALx2eZf8RV5JL4kIcE0BFAvQscRYd1yU4YVqZN9RGTQxXSvH202xvK15yZwFFxRXe60f13LJjcJ//I4Q==
@@ -8916,6 +8925,17 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+webproperty@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/webproperty/-/webproperty-1.6.3.tgz#9a7c67128159c57bd96a50f2b7f6ff92a5972fe2"
+  integrity sha512-vcFNiNS5oT8E99kSMwbif7YPfnpLlFvo9J6Bgx/gQMO2YThsv6zR3nK8WbdTT+fsHiCJuA+nkAfePFfNzptMGw==
+  dependencies:
+    bencode "^2.0.2"
+    bittorrent-dht "^10.0.2"
+    ed25519-supercop "^2.0.1"
+    level "^7.0.1"
+    simple-sha1 "^3.1.0"
 
 websocket-stream@^5.5.0, websocket-stream@^5.5.2:
   version "5.5.2"


### PR DESCRIPTION
- Adds new version of `bt-fetch` which can resolve `bittorrent://` URLs with public keys to the `infohash` for a torrent before loading it.
- Adds support to agregore's `magnet:` URL handling logic to resolve [BEP 46](http://www.bittorrent.org/beps/bep_0046.html#magnet-link) magnet links with `?xs=urn:btpk:PUBLIC_KEY` portions to `bittorrent://` URLs with the public key.

TODOs (post merge):
- Have a way to "seed" active mutable torrents while they're loaded (re-publish to the DHT?)
- Have some example mutable torrent websites for folks to visit
- Ability to `POST` to `bittorrent://` to create mutable torrents (using the same petnames for public keys feature as hyper and IPNS?)

Huge thanks to @resession for making headway on mutable torrents!