### PR TITLE
Fix/reload url on unfocus

### DIFF
--- a/app/ui/current-window.js
+++ b/app/ui/current-window.js
@@ -6,6 +6,7 @@ window.getCurrentWindow = function getCurrentWindow () {
     'navigating',
     'history-buttons-change',
     'page-title-updated',
+    'update-target-url',
     'enter-html-full-screen',
     'leave-html-full-screen',
     'close'

--- a/app/ui/current-window.js
+++ b/app/ui/current-window.js
@@ -6,9 +6,9 @@ window.getCurrentWindow = function getCurrentWindow () {
     'navigating',
     'history-buttons-change',
     'page-title-updated',
-    'update-target-url',
     'enter-html-full-screen',
     'leave-html-full-screen',
+    'update-target-url',
     'close'
   ]
 

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -17,7 +17,7 @@ class OmniBox extends HTMLElement {
         <button class="hidden omni-box-button omni-box-back" title="Go back in history">⬅</button>
         <button class="hidden omni-box-button omni-box-forward" title="Go forward in history">➡</button>
         <form class="omni-box-form">
-          <span class="omni-box-hover-url"></span>
+          <input class="omni-box-target-input" readonly></span>
           <input class="omni-box-input" title="Enter search params">
           <button class="omni-box-button" type="submit" title="Load page or Reload">⊚</button>
         </form>
@@ -27,7 +27,7 @@ class OmniBox extends HTMLElement {
     this.forwardButton = this.$('.omni-box-forward')
     this.form = this.$('.omni-box-form')
     this.input = this.$('.omni-box-input')
-    this.hoverUrl = this.$('.omni-box-hover-url')
+    this.targetUrl = this.$('.omni-box-target-input')
 
     this.input.addEventListener('focus', () => {
       this.input.select()

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -17,6 +17,7 @@ class OmniBox extends HTMLElement {
         <button class="hidden omni-box-button omni-box-back" title="Go back in history">⬅</button>
         <button class="hidden omni-box-button omni-box-forward" title="Go forward in history">➡</button>
         <form class="omni-box-form">
+          <span class="omni-box-hover-url"></span>
           <input class="omni-box-input" title="Enter search params">
           <button class="omni-box-button" type="submit" title="Load page or Reload">⊚</button>
         </form>
@@ -26,6 +27,7 @@ class OmniBox extends HTMLElement {
     this.forwardButton = this.$('.omni-box-forward')
     this.form = this.$('.omni-box-form')
     this.input = this.$('.omni-box-input')
+    this.hoverUrl = this.$('.omni-box-hover-url')
 
     this.input.addEventListener('focus', () => {
       this.input.select()

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -77,12 +77,12 @@ currentWindow.on('leave-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', false)
 })
 currentWindow.on('update-target-url', async (url) => {
-  search.hoverUrl.innerHTML = url
+  search.targetUrl.value = url
   if (url) {
-    search.hoverUrl.classList.toggle('hidden', false)
+    search.targetUrl.classList.toggle('hidden', false)
     search.input.classList.toggle('hidden', true)
   } else {
-    search.hoverUrl.classList.toggle('hidden', true)
+    search.targetUrl.classList.toggle('hidden', true)
     search.input.classList.toggle('hidden', false)
   }
 })

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -77,7 +77,14 @@ currentWindow.on('leave-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', false)
 })
 currentWindow.on('update-target-url', async (url) => {
-  url ? search.src = url : search.src = await currentWindow.getURL()
+  search.hoverUrl.innerHTML = url
+  if (url) {
+    search.hoverUrl.classList.toggle('hidden', false)
+    search.input.classList.toggle('hidden', true)
+  } else {
+    search.hoverUrl.classList.toggle('hidden', true)
+    search.input.classList.toggle('hidden', false)
+  }
 })
 
 find.addEventListener('next', ({ detail }) => {

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -70,16 +70,14 @@ currentWindow.on('history-buttons-change', updateButtons)
 currentWindow.on('page-title-updated', (title) => {
   pageTitle.innerText = title + ' - Agregore Browser'
 })
-
-currentWindow.on('update-target-url', async (url) => {
-  url ? search.src = url : search.src = await currentWindow.getURL()
-})
-
 currentWindow.on('enter-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', true)
 })
 currentWindow.on('leave-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', false)
+})
+currentWindow.on('update-target-url', async (url) => {
+  url ? search.src = url : search.src = await currentWindow.getURL()
 })
 
 find.addEventListener('next', ({ detail }) => {

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -42,7 +42,7 @@ search.addEventListener('navigate', ({ detail }) => {
 
 search.addEventListener('unfocus', async () => {
   await currentWindow.focus()
-  search.src = await webview.getURL()
+  search.src = await currentWindow.getURL()
 })
 
 search.addEventListener('search', async ({ detail }) => {

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -71,6 +71,10 @@ currentWindow.on('page-title-updated', (title) => {
   pageTitle.innerText = title + ' - Agregore Browser'
 })
 
+currentWindow.on('update-target-url', async (url) => {
+  url ? search.src = url : search.src = await currentWindow.getURL()
+})
+
 currentWindow.on('enter-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', true)
 })

--- a/app/ui/style.css
+++ b/app/ui/style.css
@@ -54,11 +54,11 @@ omni-box {
   border: none;
 }
 
-.omni-box-input, .find-menu-input, .omni-box-hover-url {
+.omni-box-input, .find-menu-input, .omni-box-target-input {
   flex: 1;
   border:none;
   background: none;
-  padding: 0.50em;
+  padding: 0.5em;
   color: inherit;
   font-size: inherit;
   font-family: inherit;

--- a/app/ui/style.css
+++ b/app/ui/style.css
@@ -54,11 +54,11 @@ omni-box {
   border: none;
 }
 
-.omni-box-input, .find-menu-input {
+.omni-box-input, .find-menu-input, .omni-box-hover-url {
   flex: 1;
   border:none;
   background: none;
-  padding: 0.5em;
+  padding: 0.50em;
   color: inherit;
   font-size: inherit;
   font-family: inherit;

--- a/app/window/index.js
+++ b/app/window/index.js
@@ -205,9 +205,6 @@ class Window extends EventEmitter {
     this.web.on('did-navigate', (event, url) => {
       this.emitNavigate(url, true)
     })
-    this.web.on('update-target-url', (event, url) => {
-      this.send('update-target-url', url)
-    })
     this.web.on('did-navigate-in-page', (event, url, isMainFrame) => {
       this.emitNavigate(url, isMainFrame)
     })
@@ -224,6 +221,9 @@ class Window extends EventEmitter {
     })
     this.window.on('leave-html-full-screen', () => {
       this.send('leave-html-full-screen')
+    })
+    this.web.on('update-target-url', (event, url) => {
+      this.send('update-target-url', url)
     })
 
     this.window.once('ready-to-show', () => this.window.show())

--- a/app/window/index.js
+++ b/app/window/index.js
@@ -205,6 +205,9 @@ class Window extends EventEmitter {
     this.web.on('did-navigate', (event, url) => {
       this.emitNavigate(url, true)
     })
+    this.web.on('update-target-url', (event, url) => {
+      this.send('update-target-url', url)
+    })
     this.web.on('did-navigate-in-page', (event, url, isMainFrame) => {
       this.emitNavigate(url, isMainFrame)
     })


### PR DESCRIPTION
The eventlistener listening to the custom `unfocus` event currently uses `webview.getURL()` which seems to have no effect.
Changing to `currentWindow.getURL()` makes the url in the omnibox update to the loaded URL when the `unfocus` event is fired.