### PR TITLE
Reload current URL on unfocus

### DIFF
--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -42,7 +42,7 @@ search.addEventListener('navigate', ({ detail }) => {
 
 search.addEventListener('unfocus', async () => {
   await currentWindow.focus()
-  search.src = await webview.getURL()
+  search.src = await currentWindow.getURL()
 })
 
 search.addEventListener('search', async ({ detail }) => {


### PR DESCRIPTION
The eventlistener listening to the custom `unfocus` event currently uses `webview.getURL()` which seems to have no effect.
Changing to `currentWindow.getURL()` makes the url in the omnibox update to the loaded URL when the `unfocus` event is fired.