### PR TITLE
add user defined appPath in .agregorerc for writing bookmarks

### DIFF
--- a/app/actions.js
+++ b/app/actions.js
@@ -7,7 +7,7 @@ const createDesktopShortcut = require('create-desktop-shortcuts')
 const dataUriToBuffer = require('data-uri-to-buffer')
 const sanitize = require('sanitize-filename')
 
-const { accelerators, extensions } = require('./config')
+const { accelerators, extensions, appPath } = require('./config')
 
 const FOCUS_URL_BAR_SCRIPT = `
 document.getElementById('search').showInput()
@@ -193,7 +193,7 @@ function createActions ({
         properties: ['openDirectory']
       })).filePaths[0]
 
-      const appPath = process.argv[0] // If testing from source find and use installed Agregore location
+      const filePath = appPath || process.argv[0] // If testing from source find and use installed Agregore location
 
       const title = webContents.getTitle()
       const shortcutName = sanitize(title, { replacement: ' ' })
@@ -201,7 +201,7 @@ function createActions ({
       const description = `Agregore Browser - ${url}`
 
       const shortcut = {
-        filePath: appPath,
+        filePath,
         outputPath: outputPath,
         name: shortcutName,
         comment: description,

--- a/docs/Bookmarks.md
+++ b/docs/Bookmarks.md
@@ -1,0 +1,11 @@
+# Bookmarks
+
+Bookmarks are stored as files. If you wish to specify the path to agregore set the `appPath` property in your `.agregorerc` config file. You may need to do this if you've moved an agregore AppImage to `/usr/bin` for example.
+
+This can be done by pressing `ALT` to bring up the menu and then clicking `Help > Edit Configuration File`, then adding in the following contents:
+
+```json
+{
+  "appPath": "/usr/bin/or/wherever/agregore-browser"
+}
+```


### PR DESCRIPTION
I mentioned this feature on discord and had a few minutes spare so just went ahead and implemented it.

```json
{
  "appPath": "/usr/bin/or/wherever/agregore-browser"
}
```

If `appPath` is in the user's config it's used, otherwise the path is obtained from `process.argv[0]` as before.