### PR TITLE
Remove experimental Wayland flags

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -35,14 +35,6 @@ app.commandLine.appendSwitch('enable-smooth-scrolling')
 app.commandLine.appendSwitch('enable-accelerated-video-decode')
 app.commandLine.appendSwitch('ignore-gpu-blacklist')
 
-// Enable flags for using Wayland rendering
-// Based on this: https://blogs.igalia.com/adunaev/2020/11/13/hidpi-support-in-chromium-for-wayland/
-// TODO: Should we do something similar for x11?
-if (process.env.XDG_SESSION_TYPE === 'wayland') {
-  app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform')
-  app.commandLine.appendSwitch('ozone-platform', 'wayland')
-}
-
 const extensions = createExtensions({ partition: WEB_PARTITION, createWindow })
 
 const windowManager = new WindowManager({


### PR DESCRIPTION
This allows Agregore to run properly under [Sway](https://swaywm.org/) for now.