### PR TITLE
move getCurrentWindow() to connected callback

### DIFF
--- a/app/ui/browser-actions.js
+++ b/app/ui/browser-actions.js
@@ -2,11 +2,12 @@
 
 class BrowserActions extends HTMLElement {
   async connectedCallback () {
+    this.current = window.getCurrentWindow()
     this.renderLatest()
   }
 
   async renderLatest () {
-    const current = window.getCurrentWindow()
+    const current = this.current
 
     const actions = await current.listExtensionActions()
     this.innerHTML = ''


### PR DESCRIPTION
this would fix too many listeners warning