### PR TITLE
Add mouse side buttons navigation #256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ package-lock.json
 
 # This gets generated post install
 app/version.js
+
+# This gets generated when I open in a Container
+.devcontainer

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -5,6 +5,7 @@ const { CID } = require('multiformats/cid')
 
 const IPNS_PREFIX = '/ipns/'
 const IPFS_PREFIX = '/ipfs/'
+const { app } = require('electron')
 
 class OmniBox extends HTMLElement {
   constructor () {
@@ -106,6 +107,26 @@ class OmniBox extends HTMLElement {
     })
     this.forwardButton.addEventListener('click', () => {
       this.dispatchEvent(new CustomEvent('forward'))
+    })
+
+    window.addEventListener("mouseup", (e) => {
+      e.preventDefault()
+
+      if(e.button === 3) {
+        this.dispatchEvent(new CustomEvent('back'))
+      } else if(e.button === 4) {
+        this.dispatchEvent(new CustomEvent('forward'))
+      }
+    })
+
+    app.whenReady().then(() => {
+      document.addEventListener('swipe', (e, direction) => {
+        if (direction === 'right') {
+          this.dispatchEvent(new CustomEvent('forward'))
+        } else if (direction === 'left') {
+          this.dispatchEvent(new CustomEvent('back'))
+        }
+      })
     })
   }
 

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -5,7 +5,6 @@ const { CID } = require('multiformats/cid')
 
 const IPNS_PREFIX = '/ipns/'
 const IPFS_PREFIX = '/ipfs/'
-const { app } = require('electron')
 
 class OmniBox extends HTMLElement {
   constructor () {
@@ -109,6 +108,7 @@ class OmniBox extends HTMLElement {
       this.dispatchEvent(new CustomEvent('forward'))
     })
 
+    // mouse side-buttons for navigating
     window.addEventListener("mouseup", (e) => {
       e.preventDefault()
 
@@ -119,14 +119,33 @@ class OmniBox extends HTMLElement {
       }
     })
 
-    app.whenReady().then(() => {
-      document.addEventListener('swipe', (e, direction) => {
-        if (direction === 'right') {
-          this.dispatchEvent(new CustomEvent('forward'))
-        } else if (direction === 'left') {
-          this.dispatchEvent(new CustomEvent('back'))
+    // mouse gestures for navigating
+    let isMouseDown = false
+    let startX = 0
+    let startY = 0
+
+    window.addEventListener('mousedown', (e) => {
+      isMouseDown = true
+      startX = e.clientX
+      startY = e.clientY
+    })
+    window.addEventListener('mousemove', (e) => {
+      if (isMouseDown) {
+        const distX = e.clientX - startX
+        const distY = e.clientY - startY
+
+        if (Math.abs(distX) > Math.abs(distY)) {
+          if (distX > 0) {
+            this.dispatchEvent(new CustomEvent('forward'))
+          } else {
+            this.dispatchEvent(new CustomEvent('back'))
+          }
         }
-      })
+        isMouseDown = false
+      }
+    })
+    window.addEventListener('mouseup', () => {
+        isMouseDown = false
     })
   }
 


### PR DESCRIPTION
So uhm... I tried working on this and reached a little bit of a pickle.
I implemented a bunch of things just to find out a day later that my mouse's side-buttons aren't apparently registered.
I also tried to implement track-pad swipe gestures, but that's still a working progress.

While rabbit holing all over the internet I found out that  JavaScript usually registers the side buttons `(mouse's 4th and 5th button)` for forward and back with code `4` and `3` respectively.
For context, I use a `Logitech mx master 3` on `linux mint`, for which they don't have a native app support...
I used [Mouse Test](https://www.clickspeedtester.com/mouse-test/) to check if they were getting registered, but they aren't...

So `TLDR` I can't test what I did, at least not on my current OS.
I might need to dual-boot windows and see. Originally thought of spinning up a vm real quick, but it came to mind that the vm might just get back the codes sent from my OS in the first place...

But in the mean time, could anyone test it and see?
Would really appreciate some feedback :)