### PR TITLE
Resolve: #296 Hide url box when going fullscreen

### DIFF
--- a/app/ui/current-window.js
+++ b/app/ui/current-window.js
@@ -10,7 +10,9 @@ window.getCurrentWindow = function getCurrentWindow () {
     'leave-html-full-screen',
     'update-target-url',
     'browser-actions-changed',
-    'close'
+    'close',
+    'enter-full-screen',
+    'leave-full-screen'
   ]
 
   class CurrentWindow extends EventEmitter {

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -78,15 +78,25 @@ currentWindow.on('page-title-updated', (title) => {
 })
 currentWindow.on('enter-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', true)
+  webview.emitResize()
 })
 currentWindow.on('leave-html-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', false)
+  webview.emitResize()
 })
 currentWindow.on('update-target-url', async (url) => {
   search.showTarget(url)
 })
 currentWindow.on('browser-actions-changed', () => {
   actions.renderLatest()
+})
+currentWindow.on('enter-full-screen', () => {
+  if (!rawFrame) nav.classList.toggle('hidden', true)
+  webview.emitResize()
+})
+currentWindow.on('leave-full-screen', () => {
+  if (!rawFrame) nav.classList.toggle('hidden', false)
+  webview.emitResize()
 })
 
 find.addEventListener('next', ({ detail }) => {

--- a/app/window.js
+++ b/app/window.js
@@ -325,6 +325,12 @@ export class Window extends EventEmitter {
     this.web.on('update-target-url', (event, url) => {
       this.send('update-target-url', url)
     })
+    this.window.on('enter-full-screen', () => {
+      this.send('enter-full-screen')
+    })
+    this.window.on('leave-full-screen', () => {
+      this.send('leave-full-screen')
+    })
 
     this.web.on('dom-ready', async () => {
       if (this.web.getURL().startsWith('agregore://settings')) {


### PR DESCRIPTION
Resolve: #296 
On [current-window.js](http://current-window.js/) added to the array EVENTS: “enter-full-screen”, “leave-full-screen”.

On [script.js](http://script.js/) added the events that detect entering and leaving the full screen and toggle the nav class ‘hidden’. Also it resizes the view. 
currentWindow.on('enter-full-screen', () => {
  if (!rawFrame) nav.classList.toggle('hidden', true)
  webview.emitResize()
})
currentWindow.on('leave-full-screen', () => {
  if (!rawFrame) nav.classList.toggle('hidden', false)
  webview.emitResize()
})

On [windows.js](http://windows.js/) added the listeners for the events: 
   this.window.on('enter-full-screen', () => {
      this.send('enter-full-screen')
    })
    this.window.on('leave-full-screen', () => {
      this.send('leave-full-screen')
    })