### PR TITLE
Add Alternative search providers

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -18,6 +18,7 @@ const DEFAULT_HYPER_DIR = path.join(USER_DATA, 'hyper')
 const DEFAULT_BT_DIR = path.join(USER_DATA, 'bt')
 
 const DEFAULT_PAGE = 'agregore://welcome'
+const DEFAULT_SEARCH_PROVIDER = 'https://duckduckgo.com/?q=%s'
 
 const DEFAULT_CONFIG_FILE_NAME = '.agregorerc'
 export const MAIN_RC_FILE = join(os.homedir(), DEFAULT_CONFIG_FILE_NAME)
@@ -65,6 +66,7 @@ const Config = RC('agregore', {
 
   defaultPage: DEFAULT_PAGE,
   autoHideMenuBar: false,
+  searchProvider: DEFAULT_SEARCH_PROVIDER,
 
   // All options here: https://github.com/ipfs/js-ipfs/blob/master/docs/CONFIG.md
   ipfsOptions: {

--- a/app/pages/settings.html
+++ b/app/pages/settings.html
@@ -16,6 +16,7 @@
     <fieldset>
         <label>Default Page: <input name="defaultPage"></label>
         <label>Auto-Hide Menu Bar: <input name="autoHideMenuBar"></label>
+        <label>Search Provider URI Template: <input name="searchProvider"></label>
     </fieldset>
     <fieldset>
         <legend id="theme">Theme</legend>

--- a/app/ui/omni-box.js
+++ b/app/ui/omni-box.js
@@ -6,6 +6,8 @@ const { CID } = require('multiformats/cid')
 const IPNS_PREFIX = '/ipns/'
 const IPFS_PREFIX = '/ipfs/'
 
+const WEB_SEARCH_QUERY_PARAM = /%s/gi
+
 class OmniBox extends HTMLElement {
   constructor () {
     super()
@@ -18,7 +20,7 @@ class OmniBox extends HTMLElement {
   }
 
   connectedCallback () {
-    this.innerHTML = ` 
+    this.innerHTML = `
       <section class="omni-box-header">
         <button class="hidden omni-box-button omni-box-back" title="Go back in history">⬅</button>
         <button class="hidden omni-box-button omni-box-up" title="Go up one directory">⬆</button>
@@ -69,7 +71,7 @@ class OmniBox extends HTMLElement {
         } else if (looksLikeDomain(rawURL)) {
           url = makeHttps(rawURL)
         } else {
-          url = makeDuckDuckGo(rawURL)
+          url = makeWebSearch(rawURL)
         }
       }
 
@@ -213,8 +215,8 @@ class OmniBox extends HTMLElement {
     } else {
       finalItems.push(
         this.makeNavItem(
-          makeDuckDuckGo(query),
-          `Search for "${query}" on DuckDuckGo`
+          makeWebSearch(query),
+          `Search for "${query}" on Web`
         )
       )
     }
@@ -314,8 +316,9 @@ function makeHttps (query) {
   return `https://${query}`
 }
 
-function makeDuckDuckGo (query) {
-  return `https://duckduckgo.com/?q=${encodeURIComponent(query)}`
+function makeWebSearch (query) {
+  const searchProvider = window.searchProvider // Initialized in script.js
+  return searchProvider.replaceAll(WEB_SEARCH_QUERY_PARAM, encodeURIComponent(query))
 }
 
 function isURL (string) {

--- a/app/ui/script.js
+++ b/app/ui/script.js
@@ -1,4 +1,5 @@
 const DEFAULT_PAGE = 'agregore://welcome'
+const DEFAULT_SEARCH_PROVIDER = 'https://duckduckgo.com/?q=%s'
 
 const webview = $('#view')
 // Kyran: Using variable name "top" causes issues for some reason? I would assume it's because of another one of the UI scripts but it doesn't seem like that's the case.
@@ -17,6 +18,9 @@ const toNavigate = searchParams.has('url') ? searchParams.get('url') : DEFAULT_P
 
 const rawFrame = searchParams.get('rawFrame') === 'true'
 const noNav = searchParams.get('noNav') === 'true'
+
+const searchProvider = searchParams.has('searchProvider') ? searchParams.get('searchProvider') : DEFAULT_SEARCH_PROVIDER
+window.searchProvider = searchProvider // Used by omni-box.js
 
 if (rawFrame) nav.classList.toggle('hidden', true)
 

--- a/app/window.js
+++ b/app/window.js
@@ -239,6 +239,7 @@ export class Window extends EventEmitter {
     listActions,
     view,
     autoHideMenuBar = Config.autoHideMenuBar || popup,
+    searchProvider = Config.searchProvider,
     ...opts
   } = {}) {
     super()
@@ -366,6 +367,7 @@ export class Window extends EventEmitter {
     if (rawFrame) toLoad.searchParams.set('rawFrame', 'true')
     if (noNav) toLoad.searchParams.set('noNav', 'true')
     if (noFocus) toLoad.searchParams.set('noFocus', 'true')
+    if (searchProvider) toLoad.searchParams.set('searchProvider', searchProvider)
 
     this.toLoad = toLoad.href
   }


### PR DESCRIPTION
## PR for issue #266 

- Add ability to change search provider URI string via config
  - %s is used to provide query
- Renamed DuckDuckGo specific strings to reflect possibility of alternate provider used
- !! Possible caveat: this requires that a user must create a new window after saving for these changes to take affect

<img height="400" alt="updated settings panel" src="https://github.com/user-attachments/assets/e3a2f400-df5c-438a-8ced-9e2e6c89faa3" />

<img height="400" alt="prompt when attempting to search" src="https://github.com/user-attachments/assets/6ae4a809-11b5-4f5a-a518-374fa682bbe4" />

Feel free to comment any changes required!