### PR TITLE
Added search providers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@
 - [Using the fetch API with the `hyper://` protocol](Fetch-Hyper.md)
 - [Using the fetch API with the `gemini://` protocol](Fetch-Gemini.md)
 - [Using the fetch API with the `ipfs://` protocol](Fetch-IPFS.md)
+- [Configuring the default web search provider](Search-Provider.md)

--- a/docs/Search-Provider.md
+++ b/docs/Search-Provider.md
@@ -1,0 +1,43 @@
+# Configuring the default web search provider
+
+By default, Agregore uses DuckDuckGo's **no-AI** search endpoint for web searches, with a URI template of:
+
+```text
+https://noai.duckduckgo.com/?ia=web&q=%s
+```
+
+The `%s` in the template is replaced with your search query.
+
+## Available Search Providers
+
+Agregore includes the following privacy-focused search providers in the settings page:
+
+- **DuckDuckGo (No AI)** - `https://noai.duckduckgo.com/?ia=web&q=%s`
+- **DuckDuckGo (With AI)** - `https://duckduckgo.com/?ia=web&q=%s`
+- **Brave Search** - `https://search.brave.com/search?q=%s`
+- **Startpage** - `https://www.startpage.com/do/dsearch?query=%s`
+- **SearX (searx.be)** - `https://searx.be/?q=%s`
+- **SearXNG (disroot)** - `https://search.disroot.org/?q=%s`
+- **Ecosia** - `https://www.ecosia.org/search?q=%s`
+- **Mojeek** - `https://www.mojeek.com/search?q=%s`
+- **Kagi** - `https://www.kagi.com/search?q=%s`
+- **Gibiru** - `https://www.gibiru.com/?q=%s`
+- **ArtadoSearch** - `https://www.artadosearch.com/search?Button1=Artado&i=%s`
+
+## Changing the Search Provider
+
+You can change the search provider in two main ways:
+
+- Via the **Settings page** at `agregore://settings`:
+  - Use the **Search Provider URI Template** field with a **datalist** dropdown containing all the privacy-focused search providers listed above.
+  - Simply select from the dropdown or type a custom search URL template containing `%s`.
+- By editing your `.agregorerc` configuration file directly and setting the `searchProvider` field to your preferred template.
+
+## Adding Custom Search Providers
+
+To add a custom search provider, simply enter the URL template in the Search Provider URI Template field. The template must contain `%s` where the search query should be inserted. For example:
+
+- Google: `https://www.google.com/search?q=%s`
+- Bing: `https://www.bing.com/search?q=%s`
+- Custom engine: `https://your-search-engine.com/search?query=%s`
+

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ const DEFAULT_HYPER_DIR = path.join(USER_DATA, 'hyper')
 const DEFAULT_BT_DIR = path.join(USER_DATA, 'bt')
 
 const DEFAULT_PAGE = 'agregore://welcome'
-const DEFAULT_SEARCH_PROVIDER = 'https://duckduckgo.com/?ia=web&q=%s'
+const DEFAULT_SEARCH_PROVIDER = 'https://noai.duckduckgo.com/?ia=web&q=%s'
 
 const DEFAULT_CONFIG_FILE_NAME = '.agregorerc'
 export const MAIN_RC_FILE = join(os.homedir(), DEFAULT_CONFIG_FILE_NAME)
@@ -178,6 +178,10 @@ export function addPreloads (session) {
 
 ipcMain.handle('settings-save', async (event, configMap) => {
   await save(configMap)
+})
+
+ipcMain.handle('settings-get', async () => {
+  return Config
 })
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,10 @@ async function onready () {
       }
     }
     if (hadThemeVars) windowManager?.updateThemeVars(themeVars)
+
+    if (configMap.searchProvider !== undefined) {
+      windowManager?.updateSearchProvider(configMap.searchProvider)
+    }
   })
 
   console.log('Opening saved windows')

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -16,7 +16,21 @@
     <fieldset>
         <label>Default Page: <input name="defaultPage"></label>
         <label>Auto-Hide Menu Bar: <input name="autoHideMenuBar"></label>
-        <label>Search Provider URI Template: <input name="searchProvider"></label>
+        <label>Search Provider URI Template: <input name="searchProvider" list="searchProviders" id="searchProviderInput"></label>
+        <datalist id="searchProviders">
+          <option value="https://noai.duckduckgo.com/?ia=web&q=%s">DuckDuckGo (No AI)</option>
+          <option value="https://duckduckgo.com/?ia=web&q=%s">DuckDuckGo (With AI)</option>
+          <option value="https://search.brave.com/search?q=%s">Brave Search</option>
+          <option value="https://www.startpage.com/do/dsearch?query=%s">Startpage</option>
+          <option value="https://searx.be/?q=%s">SearX (searx.be)</option>
+          <option value="https://search.disroot.org/?q=%s">SearXNG (disroot)</option>
+          <option value="https://www.ecosia.org/search?q=%s">Ecosia</option>
+          <option value="https://www.mojeek.com/search?q=%s">Mojeek</option>
+          <option value="https://www.kagi.com/search?q=%s">Kagi</option>
+          <option value="https://www.gibiru.com/?q=%s">Gibiru</option>
+          <option value="https://www.artadosearch.com/search?Button1=Artado&i=%s">ArtadoSearch</option>
+        </datalist>
+      
     </fieldset>
     <fieldset>
         <legend id="theme">Theme</legend>
@@ -76,7 +90,9 @@
                 }
             } else {
                 const e = $(`[name="${key}"]`)
-                if (e) e.value = JSON.stringify(value)
+                if (e) {
+                    e.value = JSON.stringify(value)
+                }
             }
         }
     }
@@ -96,4 +112,37 @@
             alert(e.message)
         }
     }
+
+    // Handle datalist selection properly with fixes for the identified issues
+    const searchProviderInput = document.getElementById('searchProviderInput')
+
+    searchProviderInput.addEventListener('focus', (e) => {
+        const currentValue = e.target.value
+        if (currentValue && currentValue.startsWith('"') && currentValue.endsWith('"')) {
+            e.target.dataset.originalValue = currentValue
+            e.target.value = ''
+        }
+    })
+
+    // Restore original value if user clicks away without selecting
+    searchProviderInput.addEventListener('blur', (e) => {
+        const currentValue = e.target.value
+        if (!currentValue && e.target.dataset.originalValue) {
+            e.target.value = e.target.dataset.originalValue
+            delete e.target.dataset.originalValue
+        }
+    })
+
+    // Listen for input events to detect datalist selection
+    searchProviderInput.addEventListener('input', (e) => {
+        const value = e.target.value
+        if (value && !value.startsWith('"') && !value.endsWith('"') && value.includes('://')) {
+            const selectedValue = JSON.stringify(value)
+            e.target.value = ''
+            setTimeout(() => {
+                e.target.value = selectedValue
+                e.target.blur()
+            }, 10)
+        }
+    })
 </script>

--- a/src/settings-preload.js
+++ b/src/settings-preload.js
@@ -3,7 +3,8 @@ const { contextBridge, ipcRenderer, webFrame } = require('electron')
 webFrame?.top?.executeJavaScript('window.location.href').then((url) => {
   if (url.startsWith('agregore://settings')) {
     contextBridge.exposeInMainWorld('settings', {
-      save: (args) => ipcRenderer.invoke('settings-save', args)
+      save: (args) => ipcRenderer.invoke('settings-save', args),
+      get: () => ipcRenderer.invoke('settings-get')
     })
   }
 })

--- a/src/ui/current-window.js
+++ b/src/ui/current-window.js
@@ -12,7 +12,8 @@ window.getCurrentWindow = function getCurrentWindow () {
     'browser-actions-changed',
     'close',
     'enter-full-screen',
-    'leave-full-screen'
+    'leave-full-screen',
+    'update-search-provider'
   ]
 
   class CurrentWindow extends EventEmitter {

--- a/src/ui/script.js
+++ b/src/ui/script.js
@@ -1,5 +1,5 @@
 const DEFAULT_PAGE = 'agregore://welcome'
-const DEFAULT_SEARCH_PROVIDER = 'https://duckduckgo.com/?ia=web&q=%s'
+const DEFAULT_SEARCH_PROVIDER = 'https://noai.duckduckgo.com/?ia=web&q=%s'
 
 const webview = $('#view')
 // Kyran: Using variable name "top" causes issues for some reason? I would assume it's because of another one of the UI scripts but it doesn't seem like that's the case.
@@ -111,6 +111,10 @@ currentWindow.on('enter-full-screen', () => {
 currentWindow.on('leave-full-screen', () => {
   if (!rawFrame) nav.classList.toggle('hidden', false)
   webview.emitResize()
+})
+
+currentWindow.on('update-search-provider', (newSearchProvider) => {
+  window.searchProvider = newSearchProvider
 })
 
 find.addEventListener('next', ({ detail }) => {

--- a/src/window.js
+++ b/src/window.js
@@ -219,6 +219,15 @@ export class WindowManager extends EventEmitter {
     )
   }
 
+  /**
+   * @param {string} searchProvider
+   */
+  updateSearchProvider (searchProvider) {
+    for (const window of this.all) {
+      window.updateSearchProvider(searchProvider)
+    }
+  }
+
   async saveOpened () {
     console.log('Saving open windows')
     /**
@@ -630,6 +639,12 @@ export class Window extends EventEmitter {
 
   get id () {
     return this.window.webContents.id
+  }
+  /**
+   * @param {string} searchProvider
+   */
+  updateSearchProvider (searchProvider) {
+    this.send('update-search-provider', searchProvider)
   }
 }
 


### PR DESCRIPTION
## Summary
Implemented datalist-based search provider selection with real-time updates across all browser windows and changed default to no-ai version of DuckDuckGo for search

## Changes Made
- Changed default string to no-ai version of DDG
- Added datalist dropdown to search provider input in settings page
- Implemented real-time updates across all open browser windows when search provider changes
- Added 11 privacy-focused search providers to the datalist options
- Maintained user experience with smooth clear/restore animation for datalist selection

## Testing Performed
- npm run lint
- Multi-window testing: Verified search provider changes update all open windows in real-time
- Datalist functionality: Tested all 11 search providers work correctly
- User experience: Confirmed smooth transitions and proper datalist behavior
- Consistency check: All files now have matching search provider lists
- Backward compatibility: Existing functionality preserved

## Related Issue
- #298 #316 

## Notes
- Users can still type custom search provider URLs containing `%s`
- Datalist provides quick selection while maintaining flexibility
- Real-time updates ensure consistent experience across multiple browser windows
- Clean implementation follows existing code patterns and best practices