### PR TITLE
fix: set window icon explicitly on Linux (GNOME/KDE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
       "executableArgs": [
         "--enable-accelerated-video"
       ],
+      "icon": "build/icon.png",
       "target": [
         "deb",
         "AppImage",

--- a/src/window.js
+++ b/src/window.js
@@ -2,7 +2,8 @@ import {
   BrowserWindow,
   BrowserView,
   ipcMain,
-  app
+  app,
+  nativeImage
 } from 'electron'
 import path from 'node:path'
 import EventEmitter from 'node:events'
@@ -426,6 +427,17 @@ export class Window extends EventEmitter {
     this.window.setVibrancy('fullscreen-ui')
     this.window.setBackgroundColor('#00000000')
     this.window.setBackgroundMaterial('mica')
+
+    // Set window icon explicitly for Linux (GNOME/KDE)
+    // Electron's BrowserWindow 'icon' option only applies to Windows/macOS
+    if (process.platform === 'linux') {
+      try {
+        const icon = nativeImage.createFromPath(LOGO_FILE)
+        this.window.setIcon(icon)
+      } catch (e) {
+        console.warn('Failed to set window icon:', e.message)
+      }
+    }
 
     this.window.setBrowserView(this.view)
 


### PR DESCRIPTION
## Summary

Fixes #10: Agregore logo not showing as window icon on Linux desktop environments (GNOME/KDE).

## Problem

Electron's `BrowserWindow` `icon` option only applies to Windows and macOS. On Linux, the window icon must be explicitly set using `nativeImage.createFromPath()` and `BrowserWindow.setIcon()`. Additionally, the electron-builder Linux configuration was missing an `icon` field for proper packaging.

## Solution

- Imported `nativeImage` from electron
- Added platform check (`process.platform === 'linux'`) and call `this.window.setIcon()` after BrowserWindow creation
- Added `"icon": "build/icon.png"` to the `linux` electron-builder configuration for proper `.desktop` entry icon

## Testing

- The icon was confirmed working on Windows and macOS
- This change adds explicit Linux icon support
- Falls back gracefully with a warning if icon loading fails

## Type of Change

- [x] Bug fix