### PR TITLE
fix: add iroh:// protocol support

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,13 @@
           "ssb"
         ],
         "role": "Viewer"
+      },
+      {
+        "name": "iroh",
+        "schemes": [
+          "iroh"
+        ],
+        "role": "Viewer"
       }
     ],
     "dmg": {
@@ -227,6 +234,7 @@
     "scoped-fs": "^1.4.1",
     "semver": "^7.5.2",
     "ssb-fetch": "^1.5.2",
-    "web3protocol": "^0.6.2"
+    "web3protocol": "^0.6.2",
+    "@number0/iroh": "^0.35.0"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -204,6 +204,11 @@ const Config = RC('agregore', {
   // DID resolution options (AT Protocol)
   didOptions: {
     plcDirectory: 'https://plc.directory'
+  },
+
+  // Iroh options
+  irohOptions: {
+    storage: DEFAULT_HYPER_DIR
   }
 })
 

--- a/src/protocols/index.js
+++ b/src/protocols/index.js
@@ -11,6 +11,7 @@ import createMagnetHandler from './magnet-protocol.js'
 import createRawHTTPSHandler from './raw-http-protocol.js'
 import createWeb3Handler from './web3-protocol.js'
 import createDIDHandler from './did-protocol.js'
+import createIrohHandler from './iroh-protocol.js'
 
 /** @import { LocalSiteTracker } from '../localsites.js' */
 
@@ -49,7 +50,8 @@ const {
   hyperOptions,
   web3Options,
   btOptions,
-  didOptions
+  didOptions,
+  irohOptions
 } = Config
 
 /** @type {(() => Promise<void>|void)[]} */
@@ -75,7 +77,8 @@ export function registerPrivileges () {
     { scheme: 'agregore', privileges: BROWSER_PRIVILEGES },
     { scheme: 'browser', privileges: BROWSER_PRIVILEGES },
     { scheme: 'magnet', privileges: LOW_PRIVILEGES },
-    { scheme: 'did', privileges: LOW_PRIVILEGES }
+    { scheme: 'did', privileges: LOW_PRIVILEGES },
+    { scheme: 'iroh', privileges: P2P_PRIVILEGES }
   ])
 }
 
@@ -93,6 +96,7 @@ export function setAsDefaultProtocolClient () {
   app.setAsDefaultProtocolClient('bittorrent')
   app.setAsDefaultProtocolClient('bt')
   app.setAsDefaultProtocolClient('web3')
+  app.setAsDefaultProtocolClient('iroh')
 }
 
 /**
@@ -176,4 +180,14 @@ export async function setupProtocols (session, tracker) {
   const didHandler = await createDIDHandler(didOptions)
   sessionProtocol.handle('did', didHandler)
   globalProtocol.handle('did', didHandler)
+
+  console.log('Registering iroh handlers')
+
+  const {
+    handler: irohHandler,
+    close: closeIroh
+  } = await createIrohHandler(irohOptions, session)
+  onCloseHandlers.push(closeIroh)
+  sessionProtocol.handle('iroh', irohHandler)
+  globalProtocol.handle('iroh', irohHandler)
 }

--- a/src/protocols/iroh-protocol.js
+++ b/src/protocols/iroh-protocol.js
@@ -1,0 +1,66 @@
+import fetchToHandler from './fetch-to-handler.js'
+import path from 'node:path'
+
+const ALPN = Object.freeze(new TextEncoder().encode('iroh-http/0.1'))
+const MAX_RESPONSE_SIZE = 64 * 1024 * 1024
+
+export default async function createHandler (irohOptions, session) {
+  return fetchToHandler(async () => {
+    const { Iroh } = await import('@number0/iroh')
+
+    const storage = irohOptions.storage
+      ? path.join(irohOptions.storage, 'iroh')
+      : undefined
+
+    const node = storage
+      ? await Iroh.persistent(storage)
+      : await Iroh.memory()
+
+    const endpoint = node.node.endpoint()
+
+    async function irohFetch (request) {
+      const url = new URL(request.url)
+      const nodeId = url.hostname
+      if (!nodeId) {
+        return new Response('Missing node ID in iroh:// URL', { status: 400 })
+      }
+
+      const pathname = url.pathname + url.search
+      const method = request.method || 'GET'
+
+      let conn
+      try {
+        conn = await endpoint.connect({ nodeId }, ALPN)
+      } catch {
+        return new Response(`Could not connect to iroh node: ${nodeId}`, { status: 502 })
+      }
+
+      const bi = await conn.openBi()
+
+      const requestHead = `${method} ${pathname} HTTP/1.1\r\n`
+      await bi.send.writeAll(new TextEncoder().encode(requestHead))
+
+      if (request.body) {
+        const reader = request.body.getReader()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          await bi.send.writeAll(value)
+        }
+      }
+
+      await bi.send.finish()
+
+      const responseBytes = await bi.recv.readToEnd(MAX_RESPONSE_SIZE)
+
+      return new Response(responseBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' }
+      })
+    }
+
+    irohFetch.close = () => node.node.shutdown()
+
+    return irohFetch
+  }, session)
+}


### PR DESCRIPTION
Adds Iroh as a new transport protocol, following step 1-3 of the issue checklist:

**URL scheme**: `iroh://<node-id>/<path>` where `<node-id>` is the base32-encoded public key of the target node.

**What this PR does:**

- Registers the `iroh://` privileged scheme in Electron
- Creates handler (`src/protocols/iroh-protocol.js`) that connects to an iroh node via `@number0/iroh`, opens a bidirectional QUIC stream, sends an HTTP-like request, and returns the response
- Adds `@number0/iroh` v0.35.0 as a dependency
- Adds config `irohOptions.storage` (defaults to same dir as hyper)
- Registers protocol in build config for OS-level protocol handling

**Not yet done (next PRs):**

- Proper HTTP/3 framing via iroh-h3 (currently uses simple request/response over bi-stream)
- DNSSEC/DNSLink resolution for iroh node IDs
- iroh server side (serve agregore website)
- Relay server on Agregore infrastructure
- LLM endpoint resolution over iroh

Closes #336