### PR TITLE
fix: display correct calendar month

### DIFF
--- a/src/pages/sites.html
+++ b/src/pages/sites.html
@@ -118,7 +118,7 @@ function actionButton(text, cb, title="") {
 function dateColumn(timestamp) {
     const date = new Date(timestamp)
     const year = date.getFullYear()
-    const month = date.getMonth().toString().padStart(2,0)
+    const month = (date.getMonth() + 1).toString().padStart(2,0)
     const day = date.getDate().toString().padStart(2,0)
     const hour = date.getHours().toString().padStart(2,0)
     const minute = date.getMinutes().toString().padStart(2,0)


### PR DESCRIPTION
## Summary

- convert the zero-based `Date#getMonth()` result to the human calendar range
- preserve the existing date/time format and zero padding

Closes #326.

## Validation

- reproduced March rendering as `02` before the change and `03` after it using the page's extracted `dateColumn()`
- verified all twelve month indices render as `01` through `12`
- compiled the extracted function and ran `git diff --check`